### PR TITLE
SPSA with last Prolix single layer net

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,6 @@ else
 endif
 
 ifneq (, $(findstring clang,$(COMPILER_VERSION)))
-    ifneq ($(DETECTED_OS),Darwin)
-        LDFLAGS += -fuse-ld=lld
-    endif
     ifeq ($(DETECTED_OS),Windows)
         ifeq (,$(shell where llvm-profdata))
             $(warning llvm-profdata not found, disabling PGO)

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ else
 endif
 
 ifneq (, $(findstring clang,$(COMPILER_VERSION)))
+    ifneq ($(DETECTED_OS),Darwin)
+        LDFLAGS += -fuse-ld=lld
+    endif
     ifeq ($(DETECTED_OS),Windows)
         ifeq (,$(shell where llvm-profdata))
             $(warning llvm-profdata not found, disabling PGO)

--- a/src/tunable.h
+++ b/src/tunable.h
@@ -28,7 +28,7 @@
 #include "util/multi_array.h"
 
 #ifndef OJ_EXTERNAL_TUNE
-	#define OJ_EXTERNAL_TUNE 1
+	#define OJ_EXTERNAL_TUNE 0
 #endif
 
 namespace oranj::tunable
@@ -102,116 +102,116 @@ namespace oranj::tunable
 #endif
 
 	OJ_TUNABLE_PARAM(defaultMovesToGo, 19, 12, 40, 1)
-	OJ_TUNABLE_PARAM_F64(incrementScale, 0.84, 0.5, 1.0, 0.05, 100)
-	OJ_TUNABLE_PARAM_F64(softTimeScale, 0.69, 0.5, 1.0, 0.05, 100)
+	OJ_TUNABLE_PARAM_F64(incrementScale, 0.79, 0.5, 1.0, 0.05, 100)
+	OJ_TUNABLE_PARAM_F64(softTimeScale, 0.72, 0.5, 1.0, 0.05, 100)
 	OJ_TUNABLE_PARAM_F64(hardTimeScale, 0.56, 0.2, 1.0, 0.05, 100)
 
-	OJ_TUNABLE_PARAM_F64(nodeTmBase, 2.62, 1.5, 3.0, 0.1, 100)
-	OJ_TUNABLE_PARAM_F64(nodeTmScale, 1.67, 1.0, 2.5, 0.1, 100)
-	OJ_TUNABLE_PARAM_F64(nodeTmScaleMin, 0.046, 0.001, 1.0, 0.1, 1000)
+	OJ_TUNABLE_PARAM_F64(nodeTmBase, 2.56, 1.5, 3.0, 0.1, 100)
+	OJ_TUNABLE_PARAM_F64(nodeTmScale, 1.69, 1.0, 2.5, 0.1, 100)
+	OJ_TUNABLE_PARAM_F64(nodeTmScaleMin, 0.110, 0.001, 1.0, 0.1, 1000)
 
-	OJ_TUNABLE_PARAM_F64(bmStabilityTmMin, 0.74, 0.4, 1.0, 0.03, 100)
-	OJ_TUNABLE_PARAM_F64(bmStabilityTmMax, 2.55, 1.2, 10.0, 0.4, 100)
-	OJ_TUNABLE_PARAM_F64(bmStabilityTmScale, 9.17, 2.0, 15.0, 0.65, 100)
-	OJ_TUNABLE_PARAM_F64(bmStabilityTmOffset, 0.81, 0.5, 2.0, 0.08, 100)
-	OJ_TUNABLE_PARAM_F64(bmStabilityTmPower, -2.66, -4.0, -1.5, 0.13, 100)
+	OJ_TUNABLE_PARAM_F64(bmStabilityTmMin, 0.73, 0.4, 1.0, 0.03, 100)
+	OJ_TUNABLE_PARAM_F64(bmStabilityTmMax, 2.08, 1.2, 10.0, 0.4, 100)
+	OJ_TUNABLE_PARAM_F64(bmStabilityTmScale, 9.29, 2.0, 15.0, 0.65, 100)
+	OJ_TUNABLE_PARAM_F64(bmStabilityTmOffset, 0.76, 0.5, 2.0, 0.08, 100)
+	OJ_TUNABLE_PARAM_F64(bmStabilityTmPower, -2.73, -4.0, -1.5, 0.13, 100)
 
-	OJ_TUNABLE_PARAM_F64(scoreTrendTmMin, 0.59, 0.4, 1.0, 0.03, 100)
-	OJ_TUNABLE_PARAM_F64(scoreTrendTmMax, 1.61, 1.2, 10.0, 0.4, 100)
-	OJ_TUNABLE_PARAM_F64(scoreTrendTmScoreScale, 4.87, 0.1, 10.0, 0.5, 100)
-	OJ_TUNABLE_PARAM_F64(scoreTrendTmStretch, 0.82, 0.1, 2.0, 0.1, 100)
-	OJ_TUNABLE_PARAM_F64(scoreTrendTmScale, 0.42, 0.1, 0.9, 0.04, 100)
-	OJ_TUNABLE_PARAM_F64(scoreTrendTmPositiveScale, 1.10, 0.5, 2.0, 0.075, 100)
-	OJ_TUNABLE_PARAM_F64(scoreTrendTmNegativeScale, 1.02, 0.5, 2.0, 0.075, 100)
+	OJ_TUNABLE_PARAM_F64(scoreTrendTmMin, 0.58, 0.4, 1.0, 0.03, 100)
+	OJ_TUNABLE_PARAM_F64(scoreTrendTmMax, 1.27, 1.2, 10.0, 0.4, 100)
+	OJ_TUNABLE_PARAM_F64(scoreTrendTmScoreScale, 5.01, 0.1, 10.0, 0.5, 100)
+	OJ_TUNABLE_PARAM_F64(scoreTrendTmStretch, 0.72, 0.1, 2.0, 0.1, 100)
+	OJ_TUNABLE_PARAM_F64(scoreTrendTmScale, 0.43, 0.1, 0.9, 0.04, 100)
+	OJ_TUNABLE_PARAM_F64(scoreTrendTmPositiveScale, 1.07, 0.5, 2.0, 0.075, 100)
+	OJ_TUNABLE_PARAM_F64(scoreTrendTmNegativeScale, 1.04, 0.5, 2.0, 0.075, 100)
 
-	OJ_TUNABLE_PARAM_F64(timeScaleMin, 0.081, 0.001, 1.0, 0.1, 1000)
+	OJ_TUNABLE_PARAM_F64(timeScaleMin, 0.115, 0.001, 1.0, 0.1, 1000)
 
-	OJ_TUNABLE_PARAM_CALLBACK(seeValuePawn, 105, 50, 200, 7.5, updateSeeValueTable)
-	OJ_TUNABLE_PARAM_CALLBACK(seeValueAlfil, 131, 50, 200, 7.5, updateSeeValueTable)
-	OJ_TUNABLE_PARAM_CALLBACK(seeValueFerz, 156, 100, 350, 15, updateSeeValueTable)
-	OJ_TUNABLE_PARAM_CALLBACK(seeValueKnight, 333, 250, 600, 25, updateSeeValueTable)
-	OJ_TUNABLE_PARAM_CALLBACK(seeValueRook, 507, 400, 1000, 30, updateSeeValueTable)
+	OJ_TUNABLE_PARAM_CALLBACK(seeValuePawn, 111, 50, 200, 7.5, updateSeeValueTable)
+	OJ_TUNABLE_PARAM_CALLBACK(seeValueAlfil, 133, 50, 200, 7.5, updateSeeValueTable)
+	OJ_TUNABLE_PARAM_CALLBACK(seeValueFerz, 152, 100, 350, 15, updateSeeValueTable)
+	OJ_TUNABLE_PARAM_CALLBACK(seeValueKnight, 321, 250, 600, 25, updateSeeValueTable)
+	OJ_TUNABLE_PARAM_CALLBACK(seeValueRook, 505, 400, 1000, 30, updateSeeValueTable)
 
-	OJ_TUNABLE_PARAM(scalingValuePawn, -3, -20, 200, 15)
-	OJ_TUNABLE_PARAM(scalingValueAlfil, 125, 50, 200, 7.5)
-	OJ_TUNABLE_PARAM(scalingValueFerz, 161, 100, 350, 15)
-	OJ_TUNABLE_PARAM(scalingValueKnight, 331, 250, 600, 25)
-	OJ_TUNABLE_PARAM(scalingValueRook, 517, 400, 1000, 30)
+	OJ_TUNABLE_PARAM(scalingValuePawn, 2, -20, 200, 15)
+	OJ_TUNABLE_PARAM(scalingValueAlfil, 122, 50, 200, 7.5)
+	OJ_TUNABLE_PARAM(scalingValueFerz, 168, 100, 350, 15)
+	OJ_TUNABLE_PARAM(scalingValueKnight, 326, 250, 600, 25)
+	OJ_TUNABLE_PARAM(scalingValueRook, 497, 400, 1000, 30)
 
-	OJ_TUNABLE_PARAM(materialScalingBase, 13256, 5000, 20000, 750)
+	OJ_TUNABLE_PARAM(materialScalingBase, 14182, 5000, 20000, 750)
 
-	OJ_TUNABLE_PARAM(pawnCorrhistWeight, 113, 32, 384, 18)
-	OJ_TUNABLE_PARAM(stmNonPawnCorrhistWeight, 116, 32, 384, 18)
-	OJ_TUNABLE_PARAM(nstmNonPawnCorrhistWeight, 128, 32, 384, 18)
-	OJ_TUNABLE_PARAM(majorCorrhistWeight, 82, 32, 384, 18)
-	OJ_TUNABLE_PARAM(contCorrhistWeight, 115, 32, 384, 18)
+	OJ_TUNABLE_PARAM(pawnCorrhistWeight, 117, 32, 384, 18)
+	OJ_TUNABLE_PARAM(stmNonPawnCorrhistWeight, 109, 32, 384, 18)
+	OJ_TUNABLE_PARAM(nstmNonPawnCorrhistWeight, 131, 32, 384, 18)
+	OJ_TUNABLE_PARAM(majorCorrhistWeight, 102, 32, 384, 18)
+	OJ_TUNABLE_PARAM(contCorrhistWeight, 102, 32, 384, 18)
 
-	OJ_TUNABLE_PARAM(initialAspWindow, 11, 4, 50, 4)
+	OJ_TUNABLE_PARAM(initialAspWindow, 13, 4, 50, 4)
 	OJ_TUNABLE_PARAM(aspWideningFactor, 17, 1, 24, 1)
 
-	OJ_TUNABLE_PARAM(goodNoisySeeOffset, 10, -384, 384, 40)
+	OJ_TUNABLE_PARAM(goodNoisySeeOffset, 25, -384, 384, 40)
 
 	OJ_TUNABLE_PARAM(rfpMargin, 69, 25, 150, 5)
 
-	OJ_TUNABLE_PARAM(razoringMargin, 310, 100, 350, 40)
+	OJ_TUNABLE_PARAM(razoringMargin, 294, 100, 350, 40)
 
-	OJ_TUNABLE_PARAM(nmpEvalReductionScale, 209, 50, 300, 25)
+	OJ_TUNABLE_PARAM(nmpEvalReductionScale, 193, 50, 300, 25)
 
-	OJ_TUNABLE_PARAM(probcutMargin, 297, 150, 400, 13)
+	OJ_TUNABLE_PARAM(probcutMargin, 306, 150, 400, 13)
 	OJ_TUNABLE_PARAM(probcutSeeScale, 17, 6, 24, 1)
 
-	OJ_TUNABLE_PARAM(fpMargin, 235, 120, 350, 45)
-	OJ_TUNABLE_PARAM(fpScale, 64, 40, 80, 8)
+	OJ_TUNABLE_PARAM(fpMargin, 229, 120, 350, 45)
+	OJ_TUNABLE_PARAM(fpScale, 59, 40, 80, 8)
 
-	OJ_TUNABLE_PARAM(quietHistPruningMargin, -2367, -4000, -1000, 175)
-	OJ_TUNABLE_PARAM(quietHistPruningOffset, -1082, -4000, 4000, 400)
+	OJ_TUNABLE_PARAM(quietHistPruningMargin, -2299, -4000, -1000, 175)
+	OJ_TUNABLE_PARAM(quietHistPruningOffset, -768, -4000, 4000, 400)
 
-	OJ_TUNABLE_PARAM(noisyHistPruningMargin, -1113, -4000, -1000, 175)
-	OJ_TUNABLE_PARAM(noisyHistPruningOffset, -869, -4000, 4000, 400)
+	OJ_TUNABLE_PARAM(noisyHistPruningMargin, -1018, -4000, -1000, 175)
+	OJ_TUNABLE_PARAM(noisyHistPruningOffset, -757, -4000, 4000, 400)
 
-	OJ_TUNABLE_PARAM(seePruningThresholdQuiet, -9, -80, -5, 12)
-	OJ_TUNABLE_PARAM(seePruningThresholdNoisy, -108, -120, -40, 20)
+	OJ_TUNABLE_PARAM(seePruningThresholdQuiet, -5, -80, -5, 12)
+	OJ_TUNABLE_PARAM(seePruningThresholdNoisy, -95, -120, -40, 20)
 
-	OJ_TUNABLE_PARAM(sBetaMargin, 4, 4, 64, 12)
+	OJ_TUNABLE_PARAM(sBetaMargin, 5, 4, 64, 12)
 
-	OJ_TUNABLE_PARAM(multiExtLimit, 10, 4, 24, 4)
+	OJ_TUNABLE_PARAM(multiExtLimit, 9, 4, 24, 4)
 
 	OJ_TUNABLE_PARAM(doubleExtMargin, 8, 0, 32, 5)
-	OJ_TUNABLE_PARAM(tripleExtMargin, 107, 10, 150, 7)
+	OJ_TUNABLE_PARAM(tripleExtMargin, 101, 10, 150, 7)
 
-	OJ_TUNABLE_PARAM_CALLBACK(quietLmrBase, 121, 50, 150, 15, updateQuietLmrTable)
-	OJ_TUNABLE_PARAM_CALLBACK(quietLmrDivisor, 213, 100, 300, 10, updateQuietLmrTable)
+	OJ_TUNABLE_PARAM_CALLBACK(quietLmrBase, 141, 50, 150, 15, updateQuietLmrTable)
+	OJ_TUNABLE_PARAM_CALLBACK(quietLmrDivisor, 219, 100, 300, 10, updateQuietLmrTable)
 
-	OJ_TUNABLE_PARAM_CALLBACK(noisyLmrBase, -25, -50, 75, 10, updateNoisyLmrTable)
-	OJ_TUNABLE_PARAM_CALLBACK(noisyLmrDivisor, 254, 150, 350, 10, updateNoisyLmrTable)
+	OJ_TUNABLE_PARAM_CALLBACK(noisyLmrBase, -36, -50, 75, 10, updateNoisyLmrTable)
+	OJ_TUNABLE_PARAM_CALLBACK(noisyLmrDivisor, 253, 150, 350, 10, updateNoisyLmrTable)
 
 	OJ_TUNABLE_PARAM(lmrNonPvReductionScale, 147, 32, 384, 12)
-	OJ_TUNABLE_PARAM(lmrTtpvReductionScale, 126, 32, 384, 12)
-	OJ_TUNABLE_PARAM(lmrImprovingReductionScale, 145, 32, 384, 12)
+	OJ_TUNABLE_PARAM(lmrTtpvReductionScale, 133, 32, 384, 12)
+	OJ_TUNABLE_PARAM(lmrImprovingReductionScale, 141, 32, 384, 12)
 	OJ_TUNABLE_PARAM(lmrCheckReductionScale, 109, 32, 384, 12)
-	OJ_TUNABLE_PARAM(lmrCutnodeReductionScale, 252, 32, 384, 12)
-	OJ_TUNABLE_PARAM(lmrHighComplexityReductionScale, 124, 32, 384, 12)
+	OJ_TUNABLE_PARAM(lmrCutnodeReductionScale, 262, 32, 384, 12)
+	OJ_TUNABLE_PARAM(lmrHighComplexityReductionScale, 118, 32, 384, 12)
 
-	OJ_TUNABLE_PARAM(lmrQuietHistoryDivisor, 11081, 4096, 16384, 650)
-	OJ_TUNABLE_PARAM(lmrNoisyHistoryDivisor, 10701, 4096, 16384, 650)
+	OJ_TUNABLE_PARAM(lmrQuietHistoryDivisor, 11346, 4096, 16384, 650)
+	OJ_TUNABLE_PARAM(lmrNoisyHistoryDivisor, 10922, 4096, 16384, 650)
 
-	OJ_TUNABLE_PARAM(lmrHighComplexityThreshold, 69, 30, 120, 5)
+	OJ_TUNABLE_PARAM(lmrHighComplexityThreshold, 68, 30, 120, 5)
 
-	OJ_TUNABLE_PARAM(lmrDeeperBase, 31, 20, 100, 6)
-	OJ_TUNABLE_PARAM(lmrDeeperScale, 5, 3, 12, 1)
+	OJ_TUNABLE_PARAM(lmrDeeperBase, 23, 20, 100, 6)
+	OJ_TUNABLE_PARAM(lmrDeeperScale, 6, 3, 12, 1)
 
-	OJ_TUNABLE_PARAM(maxHistory, 15709, 8192, 32768, 256)
+	OJ_TUNABLE_PARAM(maxHistory, 15920, 8192, 32768, 256)
 
-	OJ_TUNABLE_PARAM(maxHistoryBonus, 2558, 1024, 4096, 256)
-	OJ_TUNABLE_PARAM(historyBonusDepthScale, 254, 128, 512, 32)
-	OJ_TUNABLE_PARAM(historyBonusOffset, 383, 128, 768, 64)
+	OJ_TUNABLE_PARAM(maxHistoryBonus, 2490, 1024, 4096, 256)
+	OJ_TUNABLE_PARAM(historyBonusDepthScale, 214, 128, 512, 32)
+	OJ_TUNABLE_PARAM(historyBonusOffset, 360, 128, 768, 64)
 
-	OJ_TUNABLE_PARAM(maxHistoryPenalty, 1361, 1024, 4096, 256)
-	OJ_TUNABLE_PARAM(historyPenaltyDepthScale, 378, 128, 512, 32)
-	OJ_TUNABLE_PARAM(historyPenaltyOffset, 145, 128, 768, 64)
+	OJ_TUNABLE_PARAM(maxHistoryPenalty, 1197, 1024, 4096, 256)
+	OJ_TUNABLE_PARAM(historyPenaltyDepthScale, 343, 128, 512, 32)
+	OJ_TUNABLE_PARAM(historyPenaltyOffset, 165, 128, 768, 64)
 
-	OJ_TUNABLE_PARAM(qsearchFpMargin, 142, 50, 400, 17)
-	OJ_TUNABLE_PARAM(qsearchSeeThreshold, -96, -200, 200, 20)
+	OJ_TUNABLE_PARAM(qsearchFpMargin, 152, 50, 400, 17)
+	OJ_TUNABLE_PARAM(qsearchSeeThreshold, -105, -200, 200, 20)
 
 #undef OJ_TUNABLE_PARAM
 #undef OJ_TUNABLE_PARAM_CALLBACK

--- a/src/tunable.h
+++ b/src/tunable.h
@@ -28,7 +28,7 @@
 #include "util/multi_array.h"
 
 #ifndef OJ_EXTERNAL_TUNE
-	#define OJ_EXTERNAL_TUNE 0
+	#define OJ_EXTERNAL_TUNE 1
 #endif
 
 namespace oranj::tunable


### PR DESCRIPTION
Final update until new OJ backport

Elo   | 2.70 +- 1.83 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 23960 W: 5601 L: 5415 D: 12944
Penta | [9, 1952, 7870, 2142, 7]
http://sscg13.pythonanywhere.com/test/1899/